### PR TITLE
Use hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Once installed, you can access the following variables in your environment, proj
 
 For Rails development with the [dalli](https://github.com/mperham/dalli) client, add to `config/environments/development.rb`:
 
-    config.cache_store = :dalli_store, "127.0.0.1:#{ENV['BOXEN_MEMCACHED_PORT'] || 11211}"
+    config.cache_store = :dalli_store, "localhost:#{ENV['BOXEN_MEMCACHED_PORT'] || 11211}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,7 @@ class memcached::params {
       $datadir    = "${boxen::config::datadir}/memcached"
       $executable = "${boxen::config::homebrewdir}/bin/memcached"
       $logdir     = "${boxen::config::logdir}/memcached"
-      $host       = '127.0.0.1'
+      $host       = 'localhost'
       $port       = 21211
       $user       = $::boxen_user
 


### PR DESCRIPTION
Hi.

osx 10.9 localhost primary is ::1.
So using hostname is more useful than IP address.

Thanks.
