### PR TITLE
Realign desired Memcached version to that installed by the Homebrew formula

### DIFF
--- a/data/Darwin.yaml
+++ b/data/Darwin.yaml
@@ -2,7 +2,7 @@
 memcached::service::servicename: dev.memcached
 
 memcached::package:    'boxen/brews/memcached'
-memcached::version:    '1.4.13-boxen1'
+memcached::version:    '1.4.24-boxen1'
 
 memcached::datadir:    "%{boxen::config::datadir}/memcached"
 memcached::executable: "%{boxen::config::homebrewdir}/bin/memcached"

--- a/files/brews/memcached.rb
+++ b/files/brews/memcached.rb
@@ -5,6 +5,7 @@ class Memcached < Formula
   homepage "https://memcached.org/"
   url "https://www.memcached.org/files/memcached-1.4.24.tar.gz"
   sha256 "08a426c504ecf64633151eec1058584754d2f54e62e5ed2d6808559401617e55"
+  version "1.4.24-boxen1"
 
   bottle do
     cellar :any

--- a/manifests/lib.pp
+++ b/manifests/lib.pp
@@ -6,7 +6,7 @@ class memcached::lib {
   }
 
   package { 'boxen/brews/libmemcached':
-    ensure  => '1.0.15-boxen1',
+    ensure  => '1.4.24-boxen1',
     require => Package['boxen/brews/memcached'],
   }
 


### PR DESCRIPTION
This fixes the current problem where Boxen wants to install version 1.4.13-boxen1 but its formula installs 1.4.24. Boxen gets confused and perpetually tries to reinstall Memcached:

```
Notice: /Stage[main]/Memcached::Package/Package[boxen/brews/memcached]/ensure: ensure changed '1.4.24' to '1.4.13-boxen1'
```
